### PR TITLE
fix: local-path provisioner fsGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ Create a new Helm chart with
 cookiecutter gh:Blueshoe/hurricane-based-helm-template
 ```
 and answer the questions accordingly.
+
+# Volumes
+It is generally considered more secure to run containers with a user other than `root`. Our
+Dockerfiles usually incorporate a special user to run the application. For development
+environments such as `k3d` we're using `local-path` provisioner for local volume creation.
+This storage class does not honor the `fsGroup` option and volumes get still mounted with `root` owner 
+which leads to permission issues.  
+Anyway, you can set `volumePermissions.enabled: true` which starts an `initContainer` that simply
+`chown`s the requested volume mounts. However, you have to set 
+`podSecurityContext.fsGroup and podSecurityContext.runAsUser` to make this work. 

--- a/{{ cookiecutter.app_slug }}/helm_vars/values.yaml
+++ b/{{ cookiecutter.app_slug }}/helm_vars/values.yaml
@@ -35,6 +35,9 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+volumePermissions:
+  enabled: false
+
 service:
   type: ClusterIP
   port: 8080

--- a/{{ cookiecutter.app_slug }}/templates/deployment.yaml
+++ b/{{ cookiecutter.app_slug }}/templates/deployment.yaml
@@ -91,6 +91,24 @@ spec:
       {% if cookiecutter.use_celery_worker == "yes" or cookiecutter.use_celery_beat == "yes" -%}
       {% raw %}
       initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.podSecurityContext }}
+        - name: volume-permissions
+          image: docker.io/bitnami/bitnami-shell:10-debian-10-r125
+          imagePullPolicy: "IfNotPresent"
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - chown -R "{{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "{{ default "/var/django/" .Values.assets.assetsMountPath }}"
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: assets
+              mountPath: {{ default "/var/django/" .Values.assets.assetsMountPath }}
+        {{- end }}
         - name: init-rabbitmq-queue
           image: "{{ .Values.amqpConnect.repository }}:{{ .Values.amqpConnect.tag }}"
           imagePullPolicy: {{ .Values.amqpConnect.pullPolicy }}


### PR DESCRIPTION
Since with container images running as non-root user we get permission issues on `k3d` based developments with `local-path` provisioned volumes.
This PR to integrate a new initContainer to workaround missing fsGroup support.

See: https://github.com/rancher/local-path-provisioner/issues/41#issuecomment-907392513